### PR TITLE
exifのgpsを取得する処理を追加

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<!--
+<?xml version="1.0" encoding="utf-8"?><!--
   ~ Copyright (C) 2022 The Android Open Source Project
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,7 +17,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+
     <application
+        android:name=".DoruPlayground"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -27,7 +29,6 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.DoruPlayground"
-        android:name=".DoruPlayground"
         tools:targetApi="31">
         <activity
             android:name=".ui.MainActivity"

--- a/app/src/main/java/com/doru/reptomin/playground/data/DataItemTypeRepository.kt
+++ b/app/src/main/java/com/doru/reptomin/playground/data/DataItemTypeRepository.kt
@@ -24,7 +24,6 @@ import javax.inject.Inject
 
 interface DataItemTypeRepository {
     val dataItemTypes: Flow<List<String>>
-
     suspend fun add(name: String)
 }
 

--- a/app/src/main/java/com/doru/reptomin/playground/util/ExifUtil.kt
+++ b/app/src/main/java/com/doru/reptomin/playground/util/ExifUtil.kt
@@ -1,0 +1,23 @@
+package com.doru.reptomin.playground.util
+
+import android.content.ContentResolver
+import android.content.Context
+import android.net.Uri
+import androidx.exifinterface.media.ExifInterface
+
+class ExifUtil {
+
+    companion object {
+        @Throws(Exception::class)
+        fun getExifData(context: Context, photoUri: Uri): ExifInterface? {
+            val contentResolver: ContentResolver = context.contentResolver
+            val inputStream = contentResolver.openInputStream(photoUri)
+
+            inputStream?.use {
+                return ExifInterface(it)
+            }
+
+            return null
+        }
+    }
+}

--- a/app/src/main/java/com/doru/reptomin/playground/util/PermissionUtils.kt
+++ b/app/src/main/java/com/doru/reptomin/playground/util/PermissionUtils.kt
@@ -1,0 +1,37 @@
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import androidx.activity.compose.ManagedActivityResultLauncher
+import androidx.core.content.ContextCompat
+
+
+object PermissionUtils {
+    fun requestAccessMediaLocationPermission(
+        context: Context,
+        permissionLauncher: ManagedActivityResultLauncher<Array<String>, Map<String, Boolean>>
+    ) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val permissions = arrayOf(
+                Manifest.permission.ACCESS_MEDIA_LOCATION,
+                Manifest.permission.READ_MEDIA_IMAGES,
+            )
+            val hasPermission =
+                context.checkSelfPermission(Manifest.permission.ACCESS_MEDIA_LOCATION) == PackageManager.PERMISSION_GRANTED
+            permissionLauncher.launch(permissions)
+        } else {
+            // Android 10以前ではACCESS_MEDIA_LOCATIONが不要
+        }
+    }
+
+    fun isAccessMediaLocationPermissionGranted(context: Context): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            ContextCompat.checkSelfPermission(
+                context, Manifest.permission.ACCESS_MEDIA_LOCATION
+            ) == PackageManager.PERMISSION_GRANTED
+        } else {
+            // Android 10以前ではACCESS_MEDIA_LOCATIONが不要
+            true
+        }
+    }
+}


### PR DESCRIPTION
ドキュメントに倣って`ActivityResultContracts.PickVisualMedia()`を使用してフォトピッカーから写真選択するようにしていたが、
https://issuetracker.google.com/issues/243294058#comment1
に書いているようにexifのlatLongを取得するためには`Intent.ACTION_OPEN_DOCUMENT`によってフォトピッカーではなくコンテンツピッカー(呼び方適当)経由で写真URIを取る必要があると発覚。
対応する`ActivityResultContracts.OpenDocument()`に差し替えてなんとか成功。